### PR TITLE
Fixes WhiteSimilarity so that the algorithm matches its description from the original article.

### DIFF
--- a/lib/text/white_similarity.rb
+++ b/lib/text/white_similarity.rb
@@ -1,8 +1,6 @@
 # encoding: utf-8
 # Original author: Wilker Lúcio <wilkerlucio@gmail.com>
 
-require "set"
-
 module Text
 
   # Ruby implementation of the string similarity described by Simon White
@@ -37,21 +35,25 @@ module Text
       pairs1 = word_letter_pairs(str1)
       pairs2 = word_letter_pairs(str2)
 
+      union = pairs1.length + pairs2.length
+
+      pairs1.uniq!
+      pairs2.uniq!
+
       intersection = pairs1.inject(0) { |acc, pair|
         pairs2.include?(pair) ? acc + 1 : acc
       }
-      union = pairs1.length + pairs2.length
 
       (2.0 * intersection) / union
     end
 
   private
+
     def word_letter_pairs(str)
-      @word_letter_pairs[str] ||= Set.new(
-        str.upcase.split(/\s+/).map{ |word|
-          (0 ... (word.length - 1)).map { |i| str[i, 2] }
-        }.flatten
-      )
+      @word_letter_pairs[str] ||= str.upcase.split(/\s+/).map { |word|
+        (0 ... (word.length - 1)).map { |i| word[i, 2] }
+      }.flatten
     end
+
   end
 end

--- a/test/test_white_similarity.rb
+++ b/test/test_white_similarity.rb
@@ -26,4 +26,13 @@ class WhiteSimilarityTest < Test::Unit::TestCase
     assert_in_delta 0.25, white.similarity(word, "Help"),    0.01
     assert_in_delta 0.0,  white.similarity(word, "Sold"),    0.01
   end
+
+  def test_similarity_with_examples_from_article
+    assert_in_delta 0.4,  Text::WhiteSimilarity.similarity("GGGGG", "GG"),                           0.01
+    assert_in_delta 0.56, Text::WhiteSimilarity.similarity("REPUBLIC OF FRANCE", "FRANCE"),          0.01
+    assert_in_delta 0.0,  Text::WhiteSimilarity.similarity("FRANCE", "QUEBEC"),                      0.01
+    assert_in_delta 0.72, Text::WhiteSimilarity.similarity("FRENCH REPUBLIC", "REPUBLIC OF FRANCE"), 0.01
+    assert_in_delta 0.61, Text::WhiteSimilarity.similarity("FRENCH REPUBLIC", "REPUBLIC OF CUBA"),   0.01
+  end
+
 end


### PR DESCRIPTION
Hi,

This patch fixes the WhiteSimilarity algorithm. There are bugs in the current implementation. This patch makes sure it behaves like the example Java code from the original article.

Thanks.
