### PR TITLE
Added parameter max_distance to Levenshtein

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -12,6 +12,10 @@ A collection of text algorithms.
   # => 0
   Text::Levenshtein.distance('test', 'tent')
   # => 1
+  Text::Levenshtein.distance('test', 'testing')
+  # => 3
+  Text::Levenshtein.distance('test', 'testing', 2)
+  # => 2
 
 === Metaphone
 

--- a/lib/text/levenshtein.rb
+++ b/lib/text/levenshtein.rb
@@ -16,6 +16,10 @@ module Levenshtein
 
   # Calculate the Levenshtein distance between two strings +str1+ and +str2+.
   #
+  # Optional argument max_distance, makes the algorithm to stop if Levenshtein
+  # distance is greater or equal to it. Increase performance avoiding full
+  # distance calculations in case you only need to compare strings
+  # distances with a reference value.
   #
   # In Ruby 1.8, +str1+ and +str2+ should be ASCII, UTF-8, or a one-byte-per
   # character encoding such as ISO-8859-*. They will be treated as UTF-8 if
@@ -29,7 +33,7 @@ module Levenshtein
   # normalisation.  If there is a possibility of different normalised forms
   # being used, normalisation should be performed beforehand.
   #
-  def distance(str1, str2)
+  def distance(str1, str2, max_distance = -1)
     prepare =
       if "ruby".respond_to?(:encoding)
         lambda { |str| str.encode(Encoding::UTF_8).unpack("U*") }
@@ -44,6 +48,9 @@ module Levenshtein
     return m if n.zero?
     return n if m.zero?
 
+    # if the length difference is already greater than the max_distance, then there is nothing else to check
+    return max_distance if max_distance >= 0 && (n - m).abs >= max_distance
+
     d = (0..m).to_a
     x = nil
 
@@ -56,6 +63,11 @@ module Levenshtein
           e + 1,      # deletion
           d[j] + cost # substitution
         ].min
+
+        # if the diagonal value is already greater than the max_distance
+        # then we can safety return as diagonal will never go lower again
+        return max_distance if max_distance >= 0 && x >= max_distance
+
         d[j] = e
         e = x
       end

--- a/test/levenshtein_test.rb
+++ b/test/levenshtein_test.rb
@@ -37,8 +37,31 @@ class LevenshteinTest < Test::Unit::TestCase
     :edge => [
       ['a', 'a', 0],
       ['0123456789', 'abcdefghijklmnopqrstuvwxyz', 26]
+    ],
+    :max_distance => [
+        #max_distance = 1
+        ['gumbo', 'gumbo1', 1],
+        ['gumbo', 'gambo1', 1]
+    ],
+    :max_distance_utf8 => [
+      #max_distance = 1
+      [
+        "\347\247\201\343\201\256\345\220\215\345\211\215\343\201\257"<<
+        "\343\203\235\343\203\274\343\203\253\343\201\247\343\201\231",
+        "\343\201\274\343\201\217\343\201\256\345\220\215\345\211\215\343\201"<<
+        "\257\343\203\235\343\203\274\343\203\253\343\201\247\343\201\231",
+        1
+      ], # Japanese
+      ["fran\303\247ais", 'francais2', 1]
+    ],
+    :max_distance_iso_8859_1=> [
+      #max_distance = 1
+      ["f\366o", 'foo', 1],
+      ["fran\347ais", 'francais2', 1]
     ]
   }
+
+  MAX_DISTANCE = 1
 
   def assert_set(name)
     TEST_CASES[name].each do |s, t, x|
@@ -49,6 +72,18 @@ class LevenshteinTest < Test::Unit::TestCase
 
       assert_equal x, distance(s, t)
       assert_equal x, distance(t, s)
+    end
+  end
+
+  def assert_set_max_distance(name)
+    TEST_CASES[name].each do |s, t, x|
+      if defined?(Encoding) && Encoding.default_internal # Change the encoding if in 1.9
+        t.force_encoding(Encoding.default_internal)
+        s.force_encoding(Encoding.default_internal)
+      end
+
+      assert_equal x, distance(s, t, MAX_DISTANCE)
+      assert_equal x, distance(t, s, MAX_DISTANCE)
     end
   end
 
@@ -87,6 +122,22 @@ class LevenshteinTest < Test::Unit::TestCase
   def test_iso_8859_1_cases
     with_encoding('NONE', 'ISO-8859-1') do
       assert_set(:iso_8859_1)
+    end
+  end
+
+  def test_max_distance_cases
+    assert_set_max_distance(:max_distance)
+  end
+
+  def test_max_distance_utf8_cases
+    with_encoding('U', 'UTF-8') do
+      assert_set_max_distance(:max_distance_utf8)
+    end
+  end
+
+  def test_max_distance_iso_8859_1_cases
+    with_encoding('NONE', 'ISO-8859-1') do
+      assert_set_max_distance(:max_distance_iso_8859_1)
     end
   end
 


### PR DESCRIPTION
It allows the algorithm to return faster when only a distance comparision is needed. Very useful to speed up gettext fuzzy comparision, which discards distances greater than a max_value.
