### PR TITLE
Fix to Levenshtein max distance optimization

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -16,7 +16,7 @@ A collection of text algorithms.
   # => 3
   Text::Levenshtein.distance('test', 'testing', 2)
   # => 2
-  
+
 === Metaphone
 
   Text::Metaphone.metaphone('BRIAN')

--- a/lib/text/levenshtein.rb
+++ b/lib/text/levenshtein.rb
@@ -16,10 +16,10 @@ module Levenshtein
 
   # Calculate the Levenshtein distance between two strings +str1+ and +str2+.
   #
-  # Optional argument max_distance, makes the algorithm to stop if Levenshtein
-  # distance is greater or equal to it. Increase performance avoiding full
-  # distance calculations in case you only need to compare strings
-  # distances with a reference value.  
+  # Optional argument max_distance, reduces iterations and makes the algorithm to 
+  # stop if Levenshtein distance is greater or equal to it. Increase performance 
+  # avoiding full distance calculations in case you only need to compare strings
+  # distances with a reference value. Usually improves performance more than 100%.
   #
   # The distance is calculated in terms of Unicode codepoints. Be aware that
   # this algorithm does not perform normalisation: if there is a possibility
@@ -34,8 +34,10 @@ module Levenshtein
     end
     n = s.length
     m = t.length
+    big_int = n*m
     return m if n.zero?
     return n if m.zero?
+    return 0 if s == t
 
     # if the length difference is already greater than the max_distance, then
     # there is nothing else to check
@@ -43,16 +45,37 @@ module Levenshtein
       return max_distance
     end
     
-    d = (0..m).to_a
+    # the values necessary for our threshold are written; the ones after
+    # must be filled with large integers since the tailing member of the threshold 
+    # window in the bottom array will run min across them
+    d = Array.new(m+1) { |i| (!max_distance || i < [m, max_distance+1].min) ? i : big_int }
     x = nil
+    e = nil
 
     n.times do |i|
-      e = i + 1
-      diag_index =(t.length - s.length) + i
-      m.times do |j|
-        
+      # since we're reusing arrays, we need to be sure to wipe the value left of the
+      # starting index; we don't have to worry about the value above the ending index
+      # as the arrays were initially filled with large integers and we progress to the right
+      e = !e || !max_distance ? i + 1 : big_int
+      
+      diag_index = (t.length - s.length) + i
+      if max_distance
+        # If max_distance was specified, we can reduce second loop. So we set up our threshold window. 
+        # See:
+        # Gusfield, Dan (1997). Algorithms on strings, trees, and sequences: computer science and computational biology. 
+        # Cambridge, UK: Cambridge University Press. ISBN 0-521-58519-8.
+        # pp. 263–264. 
+        min = [0, i - max_distance - 1].max
+        max = [m-1, i + max_distance].min
+      else
+        min = 0
+        max = m-1
+      end
+
+      for j in min..max
         # if the diagonal value is already greater than the max_distance
-        # then we can safety return as diagonal will never go lower again
+        # then we can safety return. Diagonal will never go lower again.
+        # See: http://www.levenshtein.net/
         if max_distance && j == diag_index && d[j] >= max_distance
           return max_distance 
         end
@@ -63,14 +86,14 @@ module Levenshtein
           e + 1,      # deletion
           d[j] + cost # substitution
         ].min
-        
+
         d[j] = e
         e = x
       end
       d[m] = x
     end
 
-    return x
+    max_distance && x > max_distance ? max_distance : x
   end
 
   extend self

--- a/test/levenshtein_test.rb
+++ b/test/levenshtein_test.rb
@@ -48,6 +48,13 @@ class LevenshteinTest < Test::Unit::TestCase
     assert_equal 3, distance("kitten", "sitting", 4)
   end
 
+  def test_should_return_calculated_distance_when_same_as_maximum
+    assert_equal 0, distance("test", "test", 0)
+    assert_equal 1, distance("test", "tent", 1)
+    assert_equal 2, distance("gumbo", "gambol", 2)
+    assert_equal 3, distance("kitten", "sitting", 3)
+  end
+
   def test_should_return_specified_maximum_if_distance_is_more
     assert_equal 1, distance("gumbo", "gambol", 1)
     assert_equal 2, distance("kitten", "sitting", 2)
@@ -255,6 +262,12 @@ class LevenshteinTest < Test::Unit::TestCase
     assert_equal 1, distance("te", "t", 1)
     assert_equal 1, distance("te", "t", 2)
     assert_equal 1, distance("te", "t", 4) 
+  end
+
+  def test_should_return_maximum_distance_for_a_long_string
+    assert_equal 440, distance( "Having a catchy name, easy reminder for all is fundamental when choosing the name for a new product. A bad name can be the beginning of the end product and immediately forget this.</p> <p>Primary keys to choose a good brand name are, first: choose a name that only has one word and at most three, such being the optimum. Try to make it easier to read and pronounce, as this will be easier to remember for all the time to talk about your product. Remember, too, that the use of capitalization also influence, you should treat the name of your product as if it were the same logo. And finally, you should avoid using numbers in your product name, unless it is a very easy to remember because this number were tied deeply with your product. Always think globally, independent of which only sell locally, you never know when it can come out in sales and need to make a point.", 
+                                "All product lines work with tags that identify its products and differentiate it from the others or with labels for packaged, or perhaps labels to be placed in the envelopes that you send to your customers. There are thousands options, shapes, designs and colors that you can use and advantage of these is that they can also be adhesive. If you need a label that serve you and that you identify will have your order. You will receive many proposals that you can discard if they don't like you or you keep it if you like and fits your needs. Don't miss the opportunity to innovate and use all the tools that allow you to continue to grow as a company. REMEMBER! a good label, with a good design can increase your sales by 20% just by its appearance.", 
+                                440 )
   end
 
 end


### PR DESCRIPTION
Diagonal index was not correctly calculated when the levenshtein matrix was not square, but this error only affected some specific scenarios, so I have fix it. (See Note 1)

Also, I have reduced the second loop when max_distance is specified, reducing algorithm order from O(n_m) to O(max_distance_m). (See Note 2)

Finally I have added tests to capture each use case: additions (start, end, middle), deletions (start, end, middle), char change and a mix of them. If you can think of any other use case to test, just tell me and I will add it.
##### Note 1: Stop calculations when diagonal value is greater or equal than max_distance

Accoding to [A Guided Tour to Approximate String Matching, Gonzalo Navarro, Dept. of Computer Science, University of Chile](http://swp.dcc.uchile.cl/TR/1999/TR_DCC-1999-005.pdf) at page 17:

> This matrix has some properties which can be easily proved by induction (see, e.g. [Ukk85a]) 
> and which make it possible to design better algorithms. Some of the most used are that 
> the values of neighboring cells dier in at most one, and that upper-left to lower-right diagonals 
> are nondecreasing."

Also, this can be demostrated using the triangle inequality rule (The Levenshtein distance between two strings is no greater than the sum of their Levenshtein distances from a third string), explaning in [wikipedia](http://en.wikipedia.org/wiki/Levenshtein_distance), as following:

```
We can divide S (S = S[0]+S[1]+...+S[n]), so:

   L0 = LEV(S[0], T)
   L1 = LEV(S[0]+S[1], T)
   ...
   Ln = LEV(S[0]+S[1]+...+S[n], T)

So, based in the previously rule, for any N:

   LEV(S[N],T) < LEV(S[N], S[N+1]) + LEV(T, S[N+1])

But LEV(S[N], S[N+1]) is always 1, so

   LEV(S[N], T) < 1 + LEV(T, S[N+1])

and as we are using integer math, we can say that

   LEV(S[N], T) <= LEV(T, S[N+1])
```

This last formula proves that Levenshtein diagonal will never go lower.

Finally, if you check [Levenshtein site](http://www.levenshtein.net/), it says (without formal demostration): 

> The diagonal jump can cost either one, if the two characters in the row and column do not match
> or 0, if they do. 

So diagonal increase or stays the same, but never goes lower and the implemented optimization should work.
##### Note 2: Reduce second loop when max_distance is specified

According to "Gusfield, Dan (1997). Algorithms on strings, trees, and sequences: computer science and computational biology. Cambridge, UK: Cambridge University Press. pp. 263–264. ISBN 0-521-58519-8.":

> The problem is to find the best global alignment subject to the added condition that the alignment 
> contains at most k mismatches and spaces, for a given value k. The goal is to reduce the time 
> bound for the solution from 0(nm) (based on standard dynamic programming) to 0(km). 
> The basic approach is to compute the edit distance of S1 and S2 using dynamic programming 
> but fill in only an 0(km)-size portion of the full table. 

The key observation is the following: 

> If we define the main diagonal of the dynamic programming table as the cells (i, i) for i < n < m, 
> then any path in the dynamic programming table that defines a k-difference global alignment 
> must not contain any cell(i, i + l) or (i, i — l) where l is greater than k. To understand this, 
> note that any path specifying a global alignment begins on the main diagonal (in cell (0, 0)) 
> and ends on, or to the right of, the main diagonal (in cell (n, m)). Therefore, the path must 
> introduce one space in the alignment for every horizontal move that the path makes off the 
> main diagonal. Thus, only those paths that are never more than k horizontal cells from the 
> main diagonal are candidates for specifying a k-difference global alignment.
> 
> Therefore, to find any k-difference global alignment, it suffices to fill in the dynamic programming 
> table in a strip consisting of 2k + 1 cells in each row, centered on the main diagonal. When 
> assigning values to cells in that strip, the algorithm follows the established recurrence relations 
> for edit distance except for cells on the upper and lower border of the strip. Any cell on the upper 
> border of the strip ignores the term in the recurrence relation for the cell above it 
> (since it is out of the strip); similarly, any cell on the lower border ignores the term in the recurrence 
> relation for the cell to its left.

Also, in the following [stackoverflow question](http://stackoverflow.com/questions/3866249/modifying-levenshtein-distance-algorithm-to-not-calculate-all-distances) there is an implementation in JAVA.

During my tests, without the change, calling gettext:find in a big project with 10 languages, takes more than 40 mins (I interrupted it). After the changes, it finished in less than 20 mins. It is a huge performance boost.

Let me know what you think!
