### PR TITLE
Fix for max_distance option

### DIFF
--- a/lib/text/levenshtein.rb
+++ b/lib/text/levenshtein.rb
@@ -41,15 +41,16 @@ private
     n = s.length
     m = t.length
     big_int = n * m
-    return m if n.zero?
-    return n if m.zero?
-    return 0 if s == t
 
     # If the length difference is already greater than the max_distance, then
     # there is nothing else to check
     if (n - m).abs >= max_distance
       return max_distance
     end
+
+    return 0 if s == t
+    return m if n.zero?
+    return n if m.zero?
 
     # The values necessary for our threshold are written; the ones after must
     # be filled with large integers since the tailing member of the threshold

--- a/test/levenshtein_test.rb
+++ b/test/levenshtein_test.rb
@@ -48,6 +48,12 @@ class LevenshteinTest < Test::Unit::TestCase
     assert_equal 3, distance("kitten", "sitting", 4)
   end
 
+  def test_should_return_calculated_distance_when_less_than_maximum_for_empty_strings
+    assert_equal 3, distance("", "cat", 4)
+    assert_equal 3, distance("cat", "", 5)
+    assert_equal 0, distance("", "", 2)
+  end
+
   def test_should_return_calculated_distance_when_same_as_maximum
     assert_equal 0, distance("test", "test", 0)
     assert_equal 1, distance("test", "tent", 1)
@@ -55,10 +61,21 @@ class LevenshteinTest < Test::Unit::TestCase
     assert_equal 3, distance("kitten", "sitting", 3)
   end
 
+  def test_should_return_calculated_distance_when_same_as_maximum_for_empty_strings
+    assert_equal 3, distance("", "cat", 3)
+    assert_equal 3, distance("cat", "", 3)
+    assert_equal 0, distance("", "", 0)
+  end
+
   def test_should_return_specified_maximum_if_distance_is_more
     assert_equal 1, distance("gumbo", "gambol", 1)
     assert_equal 2, distance("kitten", "sitting", 2)
     assert_equal 1, distance("test", "tasf", 1)
+  end
+
+  def test_should_return_specified_maximum_if_distance_is_more_for_empty_strings
+    assert_equal 2, distance("kitten", "", 2)
+    assert_equal 3, distance("", "kitten", 3)
   end
 
   def test_should_return_maximum_distance_for_strings_with_additions_at_start


### PR DESCRIPTION
Hello,

As far as i understand, when max_distance option is passed 3 things can happen:
1. Calculated distance is less than the max: return calculated distance
2. Calculated distance is more than the max: skip the rest computation and return the max distance
3. Calculated distance is equal with the max: return either value

Should those statements hold true for the cases that contain empty strings?
If so, the commit contains breaking tests for those cases and the appropriate fix.
